### PR TITLE
Add marker parameters

### DIFF
--- a/embed-map-single-year.js
+++ b/embed-map-single-year.js
@@ -28,6 +28,14 @@ addEventListener('load', function () {
     customAttribution: attribution,
   }));
   
+  var markerLongitude = parseFloat(params.get('mlon'));
+  var markerLatitude = parseFloat(params.get('mlat'));
+  if (markerLongitude && markerLatitude) {
+    new maplibregl.Marker()
+      .setLngLat([markerLongitude, markerLatitude])
+      .addTo(map);
+  }
+  
   map.once('styledata', function (event) {
     filterByDate(map, params.get('date'));
   });


### PR DESCRIPTION
Added support for `mlat` and `mlon` parameters, as on osm.org, but as part of the fragment instead of the query string.

<img src="https://github.com/OpenHistoricalMap/ohm-embed-1yr/assets/1231218/ba21a536-6529-4a26-a25c-208a135087b3" width="400" alt="Blue marker over Black Rock City">

/ref https://github.com/OpenHistoricalMap/issues/issues/485#issuecomment-1646143474