### PR TITLE
Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Embeddable Single-Year OpenHistoricalMap
-Single year embed version of OHM default map style
+# Embeddable OpenHistoricalMap
+Embed version of OHM default map style
 
-This is a simple embeddable version of the OpenHistoricalMap default map style, with the ability to select and display a single year via URL parameter.
+This is a simple embeddable version of the OpenHistoricalMap default map style, with the ability to select and display a single year via URL parameter or animate across a timespan. The map responds to gestures interactively, but the dates can only be adjusted via the URL.
 
 The use case for this would be, for example, to embed map showing a specific place and time in a blog post about that place and time. The map is zoomable and pannable, but doesn't allow changing the year within the interface, such as is possible with the timeslider on openhistoricalmap.org.
 
@@ -23,6 +23,13 @@ OHM-specific parameters:
 
 * `date` is a valid YYYY, YYYY-MM, or YYYY-MM-DD date, but we allow the year to be a variable number of digits or negative, unlike ISO 8601-1. So here is San Marino in the year 1500 `#map=10/43.9367/12.5528&date=1500`. [See this map.](https://embed.openhistoricalmap.org/#map=10/43.9367/12.5528&date=1500)
 * `layer` is one of `O`, `W`, or `J`. This allows the selection of alternative OHM-compatible styles currently offered on openhistoricalmap.org. The default OHM style is `O`. The Japanese Scroll style is `J`. The Woodblock style is `W`. Here is a query string for San Marino in 1500 in the Woodblock style: `#map=10/43.9367/12.5528&date=1500&layer=W`. [See this map](https://embed.openhistoricalmap.org/#map=10/43.9367/12.5528&date=1500&layer=W)
+
+The map can optionally animate if you specify the following parameters:
+
+* `start_date` is the initial value of `date` at the beginning of the animation. If you also specify `date`, the `start_date` is ignored in favor of `date`.
+* `end_date` is the final value of `date` at the end of the animation.
+* `interval` is the difference in the dates depicted by any two consecutive frames of the animation, expressed as an ISO&nbsp;8601-1 duration. For example, `P10Y6M1D` advances each frame by 10&nbsp;years, 6&nbsp;months, and 1&nbsp;day, while `-P10Y6M1D` turns back the clock by 10&nbsp;years, 6&nbsp;months, and 1&nbsp;day on each frame. This parameter only supports years, months, and/or days. By default, the animation advances by one year at a time.
+* `framerate` is the frequency of the animation measured in hertz, defaulting to `1` (1 hertz, or 1 frame per second).
 
 ## Embedding
 

--- a/embed-map-single-year.js
+++ b/embed-map-single-year.js
@@ -49,17 +49,37 @@ addEventListener('load', function () {
   }
 
   map.once('styledata', function (event) {
-    filterByDate(map, params.get('date'));
+    if (params.get('start_date') || params.get('end_date')) {
+      animate(map, params.get('start_date'), params.get('end_date'));
+      return;
+    }
+    
+    let isoDate = params.get('date');
+    let date = dateFromISODate(isoDate || new Date());
+    if (date) {
+      filterByDate(map, date);
+    }
   });
 
   addEventListener('hashchange', function (event) {
     upgradeLegacyHash();
     var oldParams = new URLSearchParams(new URL(event.oldURL).hash.substring(1));
     var newParams = new URLSearchParams(new URL(event.newURL).hash.substring(1));
-    var oldDate = oldParams.get('date');
-    var newDate = newParams.get('date');
-    if (oldDate !== newDate) {
-      filterByDate(map, newDate);
+    if (newParams.get('start_date') || newParams.get('end_date')) {
+      if (oldParams.get('start_date') !== newParams.get('start_date') ||
+          oldParams.get('end_date') !== newParams.get('end_date')) {
+        animate(map, newParams.get('start_date'), newParams.get('end_date'));
+      }
+      return;
+    }
+    
+    var oldISODate = oldParams.get('date');
+    var newISODate = newParams.get('date');
+    if (oldISODate !== newISODate) {
+      let newDate = dateFromISODate(newISODate || new Date());
+      if (newDate) {
+        filterByDate(map, newDate);
+      }
     }
   });
 });
@@ -72,34 +92,80 @@ function upgradeLegacyHash() {
   location.hash = hash;
 }
 
+let animationInterval;
+
 /**
- * Filters the map’s features by the `date` data attribute.
+ * Animates the map between the given dates.
+ * 
+ * @param map The MapboxGL map object to animate.
+ * @param startDate The starting date in ISO 8601-1 format.
+ * @param endDate The ending date in ISO 8601-1 format.
+ */
+function animate(map, startDate, endDate) {
+  if (animationInterval) {
+    clearInterval(animationInterval);
+  }
+  
+  let hash = location.hash.substring(1);
+  let params = new URLSearchParams(location.hash.substring(1));
+  let duration = Duration.from(params.get('interval')) || new Duration(1);
+  let framerate = parseFloat(params.get('framerate'));
+  
+  animationInterval = setInterval(function () {
+    let hash = location.hash.substring(1);
+    let params = new URLSearchParams(location.hash.substring(1));
+    let isoDate = params.get('date') || startDate;
+    let oldDate = dateFromISODate(isoDate);
+    if (oldDate) {
+      let newDate = dateAfterDuration(oldDate, duration);
+      if (newDate <= new Date()) {
+        filterByDate(map, newDate);
+        params.set('date', newDate.toISOString().split('T')[0]);
+        location.hash = '#' + params.toString();
+      } else {
+        clearInterval(animationInterval);
+      }
+    }
+  }, 1000 / (isNaN(framerate) ? 1 : framerate));
+}
+
+/**
+ * Filters the map’s features by a date.
  *
  * @param map The MapboxGL map object to filter the style of.
- * @param date The date to filter by in YYYY-MM-DD format.
+ * @param date The date to filter by.
  */
 function filterByDate(map, date) {
-  if (date === null || date === '') {
-    date = new Date().toISOString().split('T')[0];
-  }
-  var decimalYear = date && decimalYearFromISODate(date);
-  if (!decimalYear) return;
-
+  var decimalYear = decimalYearFromDate(date);
   map.getStyle().layers.map(function (layer) {
     if (!('source-layer' in layer)) return;
 
-    var filter = constrainFilterByDate(layer.filter, decimalYear);
+    var filter = constrainFilterByDate(map.getFilter(layer.id), decimalYear);
     map.setFilter(layer.id, filter);
   });
 }
 
 /**
- * Converts the given ISO 8601-1 date to a decimal year.
+ * Converts the given date to a decimal year.
  *
- * @param isoDate A date string in ISO 8601-1 format.
+ * @param date A date object.
  * @returns A floating point number of years since year 0.
  */
-function decimalYearFromISODate(isoDate) {
+function decimalYearFromDate(date) {
+  // Add the year and the fraction of the date between two New Year’s Days.
+  let year = date.getUTCFullYear();
+  var nextNewYear = dateFromUTC(year + 1, 0, 1).getTime();
+  var lastNewYear = dateFromUTC(year, 0, 1).getTime();
+  return year + (date.getTime() - lastNewYear) / (nextNewYear - lastNewYear);
+}
+
+/**
+ * Converts the given ISO 8601-1 date to a `Date` object.
+ *
+ * @param isoDate A date string in ISO 8601-1 format.
+ * @returns A date object.
+ */
+function dateFromISODate(isoDate) {
   // Require a valid YYYY, YYYY-MM, or YYYY-MM-DD date, but allow the year
   // to be a variable number of digits or negative, unlike ISO 8601-1.
   if (!isoDate || !/^-?\d{1,4}(?:-\d\d){0,2}$/.test(isoDate)) return;
@@ -112,12 +178,45 @@ function decimalYearFromISODate(isoDate) {
   }
   var year = +ymd[0];
   var date = dateFromUTC(year, +ymd[1] - 1, +ymd[2]);
-  if (isNaN(date)) return;
+  return !isNaN(date) && date;
+}
 
-  // Add the year and the fraction of the date between two New Year’s Days.
-  var nextNewYear = dateFromUTC(year + 1, 0, 1).getTime();
-  var lastNewYear = dateFromUTC(year, 0, 1).getTime();
-  return year + (date.getTime() - lastNewYear) / (nextNewYear - lastNewYear);
+/**
+ * Similar to the `Temporal.Duration` class in TC39, but only for years, months, and days.
+ */
+function Duration(years, months, days) {
+  this.years = isNaN(years) ? 0 : years;
+  this.months = isNaN(months) ? 0 : months;
+  this.days = isNaN(days) ? 0 : days;
+}
+
+/**
+ * Converts the gven ISO 8601-1 duration to a duration object.
+ */
+Duration.from = function (isoDuration) {
+  let match = isoDuration && isoDuration.match(/^([-+])?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?$/);
+  if (match) {
+    let sign = (match[1] === '-') ? -1 : 1;
+    let years = sign * parseInt(match[2], 0);
+    let months = sign * parseInt(match[3], 0);
+    let days = sign * parseInt(match[4], 0);
+    return new Duration(years, months, days);
+  }
+};
+
+/**
+ * Returns a copy of the date advanced by the given duration.
+ * 
+ * @param date A date object.
+ * @param duration A `Duration` object to advance `date` by.
+ * @returns A date object advanced by the duration.
+ */
+function dateAfterDuration(date, duration) {
+  let newDate = date;
+  newDate.setUTCFullYear(newDate.getUTCFullYear() + duration.years);
+  newDate.setUTCMonth(newDate.getUTCMonth() + duration.months);
+  newDate.setUTCDate(newDate.getUTCDate() + duration.days);
+  return newDate;
 }
 
 /**


### PR DESCRIPTION
Added support for animating the map between two dates via the `start_date`, `end_date`, `interval`, and `framerate` URL parameters.

Here’s an example that animates a town from 1950 to 2000 by two-year intervals at 5&nbsp;frames per second:

> /path/to/ohm-embed-1yr/index.html#map=18.43/39.26827/-84.2589049&start_date=1950-01-01&end_date=2000-01-01&interval=P2Y&framerate=5