### PR TITLE
Add staging-specific layer options

### DIFF
--- a/embed-map-single-year.js
+++ b/embed-map-single-year.js
@@ -15,7 +15,7 @@ var stylesByLayer = {
   /* Woodblock (production) */
   W: 'https://www.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
   /* Woodblock (staging) */
-  W_staging: 'https://openhistoricalmap.github.io/map-styles/woodblock/woodblock.json,
+  W_staging: 'https://openhistoricalmap.github.io/map-styles/woodblock/woodblock.json',
 };
 
 addEventListener('load', function () {

--- a/embed-map-single-year.js
+++ b/embed-map-single-year.js
@@ -1,13 +1,21 @@
 var attribution = '<a href="https://www.openhistoricalmap.org/copyright">OpenHistoricalMap</a>';
 var stylesByLayer = {
-  /* Historic */
+  /* Historic (production) */
   O: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
-  /* Railway */
+  /* Historic (staging) */
+  O_staging: 'https://openhistoricalmap.github.io/map-styles/main/main.json',
+  /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
-  /* Japanese Scroll */
+  /* Railway (staging) */
+  R_staging: 'https://openhistoricalmap.github.io/map-styles/rail/rail.json',
+  /* Japanese Scroll (production) */
   J: 'https://www.openhistoricalmap.org/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
-  /* Woodblock */
+  /* Japanese Scroll (staging) */
+  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
+  /* Woodblock (production) */
   W: 'https://www.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
+  /* Woodblock (staging) */
+  W_staging: 'https://openhistoricalmap.github.io/map-styles/woodblock/woodblock.json,
 };
 
 addEventListener('load', function () {


### PR DESCRIPTION
This PR sort of walks back d8d7f2362bfd87521c4559cf59885a1282e52621 by adding a parallel set of layers pointing to stylesheets on the staging server. Append `_staging` to any `&layer=` parameter to get the staging version of that layer, for example, `&layer=R_staging` for Railway on staging. These values are undocumented for now.

Working towards OpenHistoricalMap/issues#788.