### PR TITLE
Localize labels into preferred language

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The map can optionally animate if you specify the following parameters:
 
 ### Language
 
-By default, map labels appear in your preferred language according to [your browser preferences](https://www.w3.org/International/questions/qa-lang-priorities#changing). You can also override this preference by setting the `language` parameter to an ISO&nbsp;639 language code. For example, add `&language=cop&date=700` to see [Roman Egypt labeled in Copt](https://embed.openhistoricalmap.org/#map=7/30.423/30.636&layer=O&language=cop&date=700). If OHM doesn’t have the name of a place in this preferred language, the label appears in the contemporary local language as a last resort.
+By default, map labels appear in your preferred language according to [your browser preferences](https://www.w3.org/International/questions/qa-lang-priorities#changing). You can also override this preference by setting the `language` parameter to an ISO&nbsp;639 language code. For example, add `&language=cop&date=700` to see [Roman Egypt labeled in Copt](https://embed.openhistoricalmap.org/#map=7/30.423/30.636&layer=O&language=cop&date=700). If OHM doesn’t have the name of a place in this preferred language, the label appears in the contemporary local language as a last resort. To force the display of names in contemporary local languages, set the `language` parameter to `mul` (the ISO&nbsp;639 code for multilingual content).
 
 ## Embedding
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The map can optionally animate if you specify the following parameters:
 * `interval` is the difference in the dates depicted by any two consecutive frames of the animation, expressed as an ISO&nbsp;8601-1 duration. For example, `P10Y6M1D` advances each frame by 10&nbsp;years, 6&nbsp;months, and 1&nbsp;day, while `-P10Y6M1D` turns back the clock by 10&nbsp;years, 6&nbsp;months, and 1&nbsp;day on each frame. This parameter only supports years, months, and/or days. By default, the animation advances by one year at a time.
 * `framerate` is the frequency of the animation measured in hertz, defaulting to `1` (1 hertz, or 1 frame per second).
 
+### Language
+
+By default, map labels appear in your preferred language according to [your browser preferences](https://www.w3.org/International/questions/qa-lang-priorities#changing). You can also override this preference by setting the `language` parameter to an ISO&nbsp;639 language code. For example, add `&language=cop&date=700` to see [Roman Egypt labeled in Copt](https://embed.openhistoricalmap.org/#map=7/30.423/30.636&layer=O&language=cop&date=700). If OHM doesn’t have the name of a place in this preferred language, the label appears in the contemporary local language as a last resort.
+
 ## Embedding
 
 Simply use code like this to embed:

--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ var stylesByLayer = {
 };
 
 addEventListener('load', function () {
+  // Avoid lazy-loading RTL support because it maplibre-gl-leaflet doesn’t refresh the tiles when it first loads.
+  maplibregl.setRTLTextPlugin('mapbox-gl-rtl-text.js', false);
+
   let
     params = new URLSearchParams(location.hash.substring(1)),
     style = stylesByLayer[params.get('layer') || ''] || stylesByLayer.O

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { filterByDate, dateRangeFromISODate } from '@openhistoricalmap/maplibre-gl-dates';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import MapboxLanguage from '@mapbox/mapbox-gl-language';
 
 var attribution = '<a href="https://www.openhistoricalmap.org/copyright">OpenHistoricalMap</a>';
 var stylesByLayer = {
@@ -43,6 +44,23 @@ addEventListener('load', function () {
   map.addControl(new maplibregl.NavigationControl(), 'top-left');
   map.addControl(new maplibregl.FullscreenControl(), 'top-left');
 
+  let languageCode = params.get('language');
+  let language = new MapboxLanguage({
+    defaultLanguage: languageCode,
+    supportedLanguages: languageCode,
+    languageSource: 'osm',
+    getLanguageField: (languageCode) => {
+      if (languageCode === 'mul') {
+        return 'name';
+      } else {
+        // Optimistically follow the pattern in the tiler tag mapping without hard-coding the specific table columns.
+        // https://github.com/OpenHistoricalMap/ohm-deploy/blob/main/images/tiler-server/config/languages.sql
+        return 'name_' + languageCode.replace('-', '_').toLowerCase();
+      }
+    },
+  });
+  map.addControl(language);
+
   let
     markerLongitude = parseFloat(params.get('mlon')),
     markerLatitude = parseFloat(params.get('mlat')),
@@ -77,6 +95,19 @@ addEventListener('load', function () {
     upgradeLegacyHash();
     var oldParams = new URLSearchParams(new URL(event.oldURL).hash.substring(1));
     var newParams = new URLSearchParams(new URL(event.newURL).hash.substring(1));
+
+    let oldLanguageCode = oldParams.get('language');
+    let newLanguageCode = newParams.get('language');
+    if (oldLanguageCode !== newLanguageCode) {
+      if (!language.supportedLanguages.includes(newLanguageCode)) {
+        // mapbox-gl-language assumes a limited set of language fields that is known in advance, as is the case with the Mapbox Streets source. But OHM tiles support hundreds of sparsely populated fields.
+        language.supportedLanguages.push(newLanguageCode);
+      }
+      let newStyle = language.setLanguage(map.getStyle(), newLanguageCode);
+      // Style diffing seems to miss changes to expression variable values for some reason.
+      map.setStyle(newStyle, { diff: false });
+    }
+
     if (newParams.get('start_date') || newParams.get('end_date')) {
       if (oldParams.get('start_date') !== newParams.get('start_date') ||
           oldParams.get('end_date') !== newParams.get('end_date')) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ addEventListener('load', function () {
   let languageCode = params.get('language');
   let language = new MapboxLanguage({
     defaultLanguage: languageCode,
-    supportedLanguages: languageCode,
+    supportedLanguages: languageCode ? [languageCode] : undefined,
     languageSource: 'osm',
     getLanguageField: (languageCode) => {
       if (languageCode === 'mul') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
         "@openhistoricalmap/maplibre-gl-dates": "^1.2.0",
         "maplibre-gl": "^4.5.1"
       },
@@ -445,6 +446,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/@mapbox/mapbox-gl-rtl-text": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.3.0.tgz",
+      "integrity": "sha512-OwQplFqAAEYRobrTKm2wiVP+wcpUVlgXXiUMNQ8tcm5gPN5SQRXFADmITdQOaec4LhDhuuFchS7TS8ua8dUl4w==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "@mapbox/mapbox-gl-language": "^1.0.1",
         "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
         "@openhistoricalmap/maplibre-gl-dates": "^1.2.0",
         "maplibre-gl": "^4.5.1"
@@ -447,11 +448,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@mapbox/mapbox-gl-language": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-language/-/mapbox-gl-language-1.0.1.tgz",
+      "integrity": "sha512-gL58ojl7gaWLfbSISoB2QJEfTK3j+NKvPH9og0r+c3bd5BNqhY19Eb4OPfDc5+dGmjW03LhtZBc4n2b7Xn8kjA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "mapbox-gl": ">=0.29.0"
+      }
+    },
     "node_modules/@mapbox/mapbox-gl-rtl-text": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-rtl-text/-/mapbox-gl-rtl-text-0.3.0.tgz",
       "integrity": "sha512-OwQplFqAAEYRobrTKm2wiVP+wcpUVlgXXiUMNQ8tcm5gPN5SQRXFADmITdQOaec4LhDhuuFchS7TS8ua8dUl4w==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -633,12 +650,26 @@
         "typewise-core": "^1.2"
       }
     },
+    "node_modules/cheap-ruler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/earcut": {
       "version": "3.0.0",
@@ -697,6 +728,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -783,6 +821,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -923,6 +968,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/mapbox-gl": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.5.2.tgz",
+      "integrity": "sha512-KUrmDmLFKPp3MSsWGNTH5uvtYwJknV+eFJ+vxiN6hqKpzbme37z+JfYs5Mehs3CgFaIV/pUdnEV9UPUZJPuS+Q==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
+      "workspaces": [
+        "src/style-spec",
+        "test/build/typings"
+      ],
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@types/geojson": "^7946.0.14",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^3.0.0",
+        "fflate": "^0.8.1",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "grid-index": "^1.1.0",
+        "kdbush": "^4.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "serialize-to-js": "^3.1.2",
+        "supercluster": "^8.0.1",
+        "tiny-lru": "^11.2.11",
+        "tinyqueue": "^3.0.0",
+        "tweakpane": "^4.0.4",
+        "vt-pbf": "^3.1.3"
       }
     },
     "node_modules/maplibre-gl": {
@@ -1097,6 +1191,16 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/serialize-to-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
+      "integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -1241,11 +1345,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "11.2.11",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.11.tgz",
+      "integrity": "sha512-27BIW0dIWTYYoWNnqSmoNMKe5WIbkXsc0xaCQHd3/3xT2XMuMJrzHdrO9QBFR14emBz1Bu0dOAs2sCBBrvgPQA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/tweakpane": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.4.tgz",
+      "integrity": "sha512-RkWD54zDlEbnN01wQPk0ANHGbdCvlJx/E8A1QxhTfCbX+ROWos1Ws2MnhOm39aUGMOh+36TjUwpDmLfmwTr1Fg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
+      }
     },
     "node_modules/typewise": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Embeddable map of OpenHistoricalMap",
   "main": "index.js",
   "scripts": {
-    "build": "shx mkdir -p dist && cp index.html dist && esbuild index.js --bundle --outdir=dist",
-    "start": "shx mkdir -p dist && cp index.html dist && open 'http://127.0.0.1:8000/#map=15/29.9599/-90.0676&date=1900-01-01' && esbuild index.js --bundle --outdir=dist --servedir=dist --watch"
+    "build": "npm run build:copy && esbuild index.js --bundle --outdir=dist",
+	"build:copy": "mkdir -p dist && cp index.html node_modules/@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js dist",
+    "start": "npm run build:copy && open 'http://127.0.0.1:8000/#map=15/29.9599/-90.0676&date=1900-01-01' && esbuild index.js --bundle --outdir=dist --servedir=dist --watch"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
     "shx": "^0.3.4"
   },
   "dependencies": {
+    "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
     "@openhistoricalmap/maplibre-gl-dates": "^1.2.0",
     "maplibre-gl": "^4.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npm run build:copy && esbuild index.js --bundle --outdir=dist",
-	"build:copy": "mkdir -p dist && cp index.html node_modules/@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js dist",
+    "build:copy": "mkdir -p dist && cp index.html node_modules/@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js dist",
     "start": "npm run build:copy && open 'http://127.0.0.1:8000/#map=15/29.9599/-90.0676&date=1900-01-01' && esbuild index.js --bundle --outdir=dist --servedir=dist --watch"
   },
   "repository": {
@@ -27,6 +27,7 @@
     "shx": "^0.3.4"
   },
   "dependencies": {
+    "@mapbox/mapbox-gl-language": "^1.0.1",
     "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
     "@openhistoricalmap/maplibre-gl-dates": "^1.2.0",
     "maplibre-gl": "^4.5.1"


### PR DESCRIPTION
By default, labels now show the user’s preferred language or the language specified in the URL, falling back to the contemporary local language (`name`). Only the styles on staging are supported while we wait for OpenHistoricalMap/issues#679 and OpenHistoricalMap/issues#775 to be deployed to production.

This functionality currently relies on mapbox-gl-language as a stopgap, but with all the miserable workarounds I’ve had to put in this PR, such as https://github.com/mapbox/mapbox-gl-language/issues/63#issuecomment-2276884098, I’m eager for OSM Americana’s much more robust localization functionality to become available for reuse: osm-americana/openstreetmap-americana#914.

With label localization in place, it becomes much more important to avoid viciously mangling Arabic text and Hebrew _ktiv menuqad_. I’ve installed the mapbox-gl-rtl-text plugin, which was installed on the main site in OpenHistoricalMap/issues#359.

For example, if you run `npm install && npm start`, here’s [Roman Egypt in 700 CE in Coptic](http://127.0.0.1:8000/#map=7/30.423/30.636&layer=O_staging&language=cop&date=700):

![A map of Roman Egypt in 700 CE, with arrows pointing to three labels in Coptic for Rosetta, Damietta, and Faiyum.](https://github.com/user-attachments/assets/921ebd06-474c-4496-8fb4-cc9bc9cce7d1)

Working towards OpenHistoricalMap/issues#481 and OpenHistoricalMap/issues#854.