### PR TITLE
Add globe control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,23 @@ Visit the map directly at [embed.openhistoricalmap.org](https://embed.openhistor
 
 ## URL parameters
 
+### Viewport
+
 The URL has typical z/x/y parameters for map zoom and center.
 
 So a parameter like `#map=10/43.9367/12.5528` is zoom 10 showing San Marino in Italy, which is at `43.9367/12.5528` in `lon,lat` format of decimal degrees. [See the map.](https://embed.openhistoricalmap.org/#map=10/43.9367/12.5528)
 
 An embedded map is typically of a different size and aspect ratio from the original and thus must be scaled in order to cover a comparable area. This is accomplished by passing the original map's bounding box in the hash as `&bbox=minlon,minlat,maxlon,maxlat`. Once the embedded map gets its initial framing from the `bbox` the normal hash mechanism takes over. The San Marino example could be bounded by appending `&bbox=12.321338653564453,43.86782687726672,12.58037567138672,44.008373185063874` to the URL. [See this map.](https://embed.openhistoricalmap.org/#map=10/43.9367/12.5528&bbox=12.321338653564453,43.86782687726672,12.58037567138672,44.008373185063874)
+
+### Projection
+
+The `projection` parameter accepts the following values:
+
+* `mercator`, Web Mercator projection, represents the world as a square. It allows you to view both hemispheres at the same time but with extreme area distortion at the upper latitudes. This is the default projection.
+* `vertical-perspective`, Vertical Perspective projection, resembles a globe. It avoids area distortion but only shows one hemisphere at a time.
+* `globe` is a hybrid of `vertical-perspective` at low zoom levels and `mercator` at high zoom levels where the Web Mercator projection’s distortions matter much less.
+
+The 🌐 button at the upper-left corner toggles between `mercator` and `globe` projection.
 
 ### Dates
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ addEventListener('load', function () {
   });
 
   map.addControl(new maplibregl.NavigationControl(), 'top-left');
+  map.addControl(new maplibregl.GlobeControl(), 'top-left');
   map.addControl(new maplibregl.FullscreenControl(), 'top-left');
 
   let languageCode = params.get('language');

--- a/index.js
+++ b/index.js
@@ -83,6 +83,12 @@ addEventListener('load', function () {
   }
 
   map.once('styledata', function (event) {
+    if (params.get('projection')) {
+      map.setProjection({
+          type: params.get('projection'),
+      });
+    }
+
     if (params.get('start_date') || params.get('end_date')) {
       animate(map, params.get('start_date'), params.get('end_date'));
       return;
@@ -107,6 +113,12 @@ addEventListener('load', function () {
       let newStyle = language.setLanguage(map.getStyle(), newLanguageCode);
       // Style diffing seems to miss changes to expression variable values for some reason.
       map.setStyle(newStyle, { diff: false });
+    }
+
+    if (oldParams.get('projection') !== newParams.get('projection')) {
+      map.setProjection({
+          type: newParams.get('projection') || 'mercator',
+      });
     }
 
     if (newParams.get('start_date') || newParams.get('end_date')) {


### PR DESCRIPTION
Added a button to the upper-left corner of the map that toggles between Web Mercator and Vertical Perspective (“globe”) projection at low zoom levels. The latter has much less distortion but may impact legibility in some cases.

A new `projection` parameter accepts MapLibre [projection identifiers](https://maplibre.org/maplibre-style-spec/types/#projectiondefinition) and presets, such as `mercator` and `globe`.

![Western hemisphere in 1650](https://github.com/user-attachments/assets/dbfbf3c5-766c-4cd6-8aa6-70826e17b14e)
![Eastern hemisphere in 1923](https://github.com/user-attachments/assets/ec08ea1e-d878-4946-b0b6-14a184503991)
![Europe in 1066, Woodblock style](https://github.com/user-attachments/assets/e4e4a1fe-cd9a-4ccd-9bb5-e9b994ac27f4)
