### PR TITLE
Update staging URL for Historical Map Style

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var stylesByLayer = {
   /* Historic (production) */
   O: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
   /* Historic (staging) */
-  O_staging: 'https://openhistoricalmap.github.io/map-styles/main/main.json',
+  O_staging: 'https://openhistoricalmap.github.io/map-styles/historical/historical.json',
   /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
   /* Railway (staging) */

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ var stylesByLayer = {
   /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
   /* Railway (staging) */
-  R_staging: 'https://openhistoricalmap.github.io/map-styles/rail/rail.json',
+  R_staging: 'https://openhistoricalmap.github.io/map-styles/railway/railway.json',
   /* Japanese Scroll (production) */
   J: 'https://www.openhistoricalmap.org/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
   /* Japanese Scroll (staging) */
-  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
+  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/japanese_scroll.json',
   /* Woodblock (production) */
   W: 'https://www.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
   /* Woodblock (staging) */


### PR DESCRIPTION
This is a fix for a change from https://github.com/OpenHistoricalMap/map-styles/pull/32 that affected the name of the Historical (was Main) OHM map style in the map-styles repo