### PR TITLE
Update main map style url

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var stylesByLayer = {
   /* Historic (production) */
   O: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
   /* Historic (staging) */
-  O_staging: 'https://openhistoricalmap.github.io/map-styles/main/main.json',
+  O_staging: 'https://openhistoricalmap.github.io/map-styles/historical/historical.json',
   /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
   /* Railway (staging) */

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 var attribution = '<a href="https://www.openhistoricalmap.org/copyright">OpenHistoricalMap</a>';
 var stylesByLayer = {
   /* Historic (production) */
-  O: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
+  O: 'https://www.openhistoricalmap.org/map-styles/historical/historical.json',
   /* Historic (staging) */
   O_staging: 'https://openhistoricalmap.github.io/map-styles/historical/historical.json',
   /* Railway (production) */

--- a/index.js
+++ b/index.js
@@ -8,19 +8,19 @@ var stylesByLayer = {
   /* Historic (production) */
   O: 'https://www.openhistoricalmap.org/map-styles/historical/historical.json',
   /* Historic (staging) */
-  O_staging: 'https://openhistoricalmap.github.io/map-styles/historical/historical.json',
+  O_staging: 'https://www.staging.openhistoricalmap.org/map-styles/historical/historical.json',
   /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
   /* Railway (staging) */
-  R_staging: 'https://openhistoricalmap.github.io/map-styles/railway/railway.json',
+  R_staging: 'https://www.staging.openhistoricalmap.org/map-styles/railway/railway.json',
   /* Japanese Scroll (production) */
   J: 'https://www.openhistoricalmap.org/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
   /* Japanese Scroll (staging) */
-  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/japanese_scroll.json',
+  J_staging: 'https://www.staging.openhistoricalmap.org/map-styles/japanese_scroll/japanese_scroll.json',
   /* Woodblock (production) */
   W: 'https://www.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
   /* Woodblock (staging) */
-  W_staging: 'https://openhistoricalmap.github.io/map-styles/woodblock/woodblock.json',
+  W_staging: 'https://www.staging.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
 };
 
 addEventListener('load', function () {

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ var stylesByLayer = {
   /* Railway (production) */
   R: 'https://www.openhistoricalmap.org/map-styles/rail/rail.json',
   /* Railway (staging) */
-  R_staging: 'https://openhistoricalmap.github.io/map-styles/rail/rail.json',
+  R_staging: 'https://openhistoricalmap.github.io/map-styles/railway/railway.json',
   /* Japanese Scroll (production) */
   J: 'https://www.openhistoricalmap.org/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
   /* Japanese Scroll (staging) */
-  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/ohm-japanese-scroll-map.json',
+  J_staging: 'https://openhistoricalmap.github.io/map-styles/japanese_scroll/japanese_scroll.json',
   /* Woodblock (production) */
   W: 'https://www.openhistoricalmap.org/map-styles/woodblock/woodblock.json',
   /* Woodblock (staging) */


### PR DESCRIPTION
This is pending the merge of https://github.com/OpenHistoricalMap/ohm-website/pull/269 and should be merge only after that change. Note that we will also have a redirect of `main/main.json` to `/historical/historical.json`, so this PR is really about showing what we want people to do, and there should be no downtime

cc @erictheise @1ec5 